### PR TITLE
MIDRC-901 Do not copy all original headers

### DIFF
--- a/gen3workflow/routes/s3.py
+++ b/gen3workflow/routes/s3.py
@@ -109,7 +109,12 @@ async def s3_endpoint(path: str, request: Request):
     region = config["USER_BUCKETS_REGION"]
     service = "s3"
 
-    # generate the request headers
+    # generate the request headers.
+    # overwrite the original `x-amz-content-sha256` header value with the body hash. When this
+    # header is set to "STREAMING-AWS4-HMAC-SHA256-PAYLOAD" in the original request (payload sent
+    # over multiple chunks), we still replace it with the body hash (because I couldn't get the
+    # signing to work for "STREAMING-AWS4-HMAC-SHA256-PAYLOAD" - I believe it requires using the signature from the previous chunk).
+    # NOTE: This may cause issues when large files are _actually_ uploaded over multiple chunks.
     headers = {
         "host": f"{user_bucket}.s3.amazonaws.com",
         "x-amz-content-sha256": body_hash,


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/MIDRC-901

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
- There are too many variables that could make the s3 requests fail (SignatureDoesNotMatch) when copying all the original request headers - only set required headers instead

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
