### PR TITLE
Update authz path for `gen3-workflow/user-bucket`

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -13,7 +13,7 @@ Contents:
   - Users are automatically granted access to `/users/<user ID>/gen3-workflow/tasks` so they can view their own tasks.
   - Admin access (the ability to see _all_ users’ tasks instead of just your own) can be granted to a user by granting them access to the parent resource `/services/workflow/gen3-workflow/tasks`.
   - This supports sharing tasks with others; for example, "user1" may share "taskA" with "user2" if the system grants "user2" access to `/users/user1/gen3-workflow/tasks/taskA`.
-- To delete their own S3 bucket along with all its objects, a user needs `delete` access to the resource `/services/workflow/user-bucket` on the `gen3-workflow` service -- a special privilege useful for automated testing but not intended for the average user.
+- To delete their own S3 bucket along with all its objects, a user needs `delete` access to the resource `/services/workflow/gen3-workflow/user-bucket` on the `gen3-workflow` service -- a special privilege useful for automated testing but not intended for the average user.
 
 #### Authorization configuration example
 

--- a/gen3workflow/routes/storage.py
+++ b/gen3workflow/routes/storage.py
@@ -23,7 +23,7 @@ async def get_storage_info(request: Request, auth=Depends(Auth)) -> dict:
 
 @router.delete("/user-bucket", status_code=HTTP_204_NO_CONTENT)
 async def delete_user_bucket(request: Request, auth=Depends(Auth)) -> None:
-    await auth.authorize("delete", ["/services/workflow/user-bucket"])
+    await auth.authorize("delete", ["/services/workflow/gen3-workflow/user-bucket"])
 
     token_claims = await auth.get_token_claims()
     user_id = token_claims.get("sub")


### PR DESCRIPTION
### Bug Fixes
* Authz path for DELETE user-bucket updated to `/services/workflow/gen3-workflow/user-bucket`