### PR TITLE
Add s3:DeleteObject permission for users' own bucket

### DIFF
--- a/gen3workflow/aws_utils.py
+++ b/gen3workflow/aws_utils.py
@@ -216,6 +216,7 @@ def create_iam_role_for_bucket_access(user_id: str) -> str:
                 "Action": [
                     "s3:PutObject",
                     "s3:GetObject",
+                    "s3:DeleteObject",
                 ],
                 "Resource": f"arn:aws:s3:::{bucket_name}/*",
             },

--- a/tests/test_aws_utils.py
+++ b/tests/test_aws_utils.py
@@ -113,6 +113,7 @@ def test_create_role_for_bucket_access_creates_role_when_missing(mock_aws_servic
                     "Action": [
                         "s3:PutObject",
                         "s3:GetObject",
+                        "s3:DeleteObject",
                     ],
                     "Resource": f"arn:aws:s3:::gen3wf-localhost-{TEST_USER_ID}/*",
                 },
@@ -287,6 +288,7 @@ def test_create_role_for_bucket_access_with_no_kms_enabled(
                     "Action": [
                         "s3:PutObject",
                         "s3:GetObject",
+                        "s3:DeleteObject",
                     ],
                     "Resource": f"arn:aws:s3:::gen3wf-localhost-{TEST_USER_ID}/*",
                 },


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features
* Users can now delete their own S3 bucket objects. 
### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
