### PR TITLE
Fix setup storage authz to return 401 before 403

### DIFF
--- a/gen3workflow/routes/storage.py
+++ b/gen3workflow/routes/storage.py
@@ -23,9 +23,6 @@ async def storage_setup(request: Request, auth=Depends(Auth)) -> dict:
     This endpoint also serves as a mandatory "first time setup" for the user's bucket
     and authz.
     """
-    # only users with access to create tasks should be able to setup their storage
-    await auth.authorize("create", ["/services/workflow/gen3-workflow/tasks"])
-
     token_claims = await auth.get_token_claims()
     user_id = token_claims.get("sub")
     logger.info(f"User '{user_id}' getting their own storage info")
@@ -35,6 +32,9 @@ async def storage_setup(request: Request, auth=Depends(Auth)) -> dict:
         err_msg = "No context.user.name in token"
         logger.error(err_msg)
         raise HTTPException(HTTP_401_UNAUTHORIZED, err_msg)
+
+    # only users with access to create tasks should be able to setup their storage
+    await auth.authorize("create", ["/services/workflow/gen3-workflow/tasks"])
 
     bucket_name, bucket_prefix, bucket_region, kms_key_arn = (
         await aws_utils.create_user_bucket(user_id)


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
- Fix `/setup/storage` authorization check to return 401 before 403 when there is no provided access token

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
