### PR TITLE
Fix 'Object of type HTTPException is not JSON serializable'

### DIFF
--- a/gen3workflow/auth.py
+++ b/gen3workflow/auth.py
@@ -101,7 +101,7 @@ class Auth:
             return token_claims.get("exp", 0) < time.time() + CACHE_SECONDS
         except Exception as e:
             logger.error(f"Unable to check access token expiration: {e}")
-            raise HTTPException(HTTP_401_UNAUTHORIZED, e)
+            raise HTTPException(HTTP_401_UNAUTHORIZED, e.detail)
 
     async def authorize(
         self,

--- a/tests/test_ga4gh_tes.py
+++ b/tests/test_ga4gh_tes.py
@@ -2,14 +2,12 @@ import json
 from unittest.mock import patch
 
 import pytest
-import pytest_asyncio
 
 from gen3workflow.config import config
 from tests.conftest import (
     mock_arborist_request,
     mock_tes_server_request,
     TEST_USER_ID,
-    NEW_TEST_USER_ID,
     TEST_USER_TOKEN,
 )
 


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

```
  File "/gen3workflow/gen3workflow/auth.py", line 104, in is_token_close_to_expiry
    raise HTTPException(HTTP_401_UNAUTHORIZED, e)
fastapi.exceptions.HTTPException: 401: 401: Could not verify, parse, and/or validate provided access token
[...]
  File "/venv/lib64/python3.13/site-packages/starlette/responses.py", line 195, in render
    return json.dumps(
           ~~~~~~~~~~^
        content,
        ^^^^^^^^
[...]
  File "/usr/lib64/python3.13/json/encoder.py", line 182, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
                    f'is not JSON serializable')
```

### New Features

### Breaking Changes

### Bug Fixes
- Fix "Object of type HTTPException is not JSON serializable" error when using an expired access token

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
